### PR TITLE
fix(eslint-config): capitalize first comment line only

### DIFF
--- a/.changeset/tidy-forks-wait.md
+++ b/.changeset/tidy-forks-wait.md
@@ -1,0 +1,5 @@
+---
+"@spear-ai/eslint-config": patch
+---
+
+Fixed ESLint Config’s comment capitalization rule to only apply to the first line.

--- a/packages/eslint-config/src/index.ts
+++ b/packages/eslint-config/src/index.ts
@@ -335,7 +335,7 @@ export const baseEslintConfig: Linter.FlatConfig[] = [
           natural: true,
         },
       ],
-      "capitalized-comments": ["warn", "always"],
+      "capitalized-comments": ["warn", "always", { ignoreConsecutiveComments: true }],
       "dot-notation": ["off"],
       "formatjs/enforce-default-message": ["error"],
       "formatjs/enforce-id": [


### PR DESCRIPTION
This allows multi-line sentences to have proper casing.