### PR TITLE
Ruff Python version inference

### DIFF
--- a/.changeset/big-rings-relate.md
+++ b/.changeset/big-rings-relate.md
@@ -1,0 +1,6 @@
+---
+"@spear-ai/ruff-config": major
+---
+
+Updated the Ruff version to allow Python version inference and removed the arbitrary Ruff Python 3.11 version pin.
+Ruff now uses the Python version specified in the pyproject.toml file.

--- a/packages/ruff-config/README.md
+++ b/packages/ruff-config/README.md
@@ -17,8 +17,8 @@ Configure `poetry.toml` to save the virtual environment to your local project:
 in-project = true
 ```
 
-Add the following to your `ruff.toml` file:
+Add the following to your `ruff.toml` file, modifying the path to your virtual environment site-packages directory as necessary:
 
 ```toml
-extend = "./.venv/lib/python3.11/site-packages/spear-ai-ruff-config/config.toml"
+extend = "./.venv/lib/python3.10/site-packages/spear-ai-ruff-config/config.toml"
 ```

--- a/packages/ruff-config/poetry.lock
+++ b/packages/ruff-config/poetry.lock
@@ -2,33 +2,33 @@
 
 [[package]]
 name = "ruff"
-version = "0.6.9"
+version = "0.11.5"
 description = "An extremely fast Python linter and code formatter, written in Rust."
 optional = false
 python-versions = ">=3.7"
 groups = ["main"]
 files = [
-    {file = "ruff-0.6.9-py3-none-linux_armv6l.whl", hash = "sha256:064df58d84ccc0ac0fcd63bc3090b251d90e2a372558c0f057c3f75ed73e1ccd"},
-    {file = "ruff-0.6.9-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:140d4b5c9f5fc7a7b074908a78ab8d384dd7f6510402267bc76c37195c02a7ec"},
-    {file = "ruff-0.6.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:53fd8ca5e82bdee8da7f506d7b03a261f24cd43d090ea9db9a1dc59d9313914c"},
-    {file = "ruff-0.6.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:645d7d8761f915e48a00d4ecc3686969761df69fb561dd914a773c1a8266e14e"},
-    {file = "ruff-0.6.9-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:eae02b700763e3847595b9d2891488989cac00214da7f845f4bcf2989007d577"},
-    {file = "ruff-0.6.9-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7d5ccc9e58112441de8ad4b29dcb7a86dc25c5f770e3c06a9d57e0e5eba48829"},
-    {file = "ruff-0.6.9-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:417b81aa1c9b60b2f8edc463c58363075412866ae4e2b9ab0f690dc1e87ac1b5"},
-    {file = "ruff-0.6.9-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3c866b631f5fbce896a74a6e4383407ba7507b815ccc52bcedabb6810fdb3ef7"},
-    {file = "ruff-0.6.9-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7b118afbb3202f5911486ad52da86d1d52305b59e7ef2031cea3425142b97d6f"},
-    {file = "ruff-0.6.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a67267654edc23c97335586774790cde402fb6bbdb3c2314f1fc087dee320bfa"},
-    {file = "ruff-0.6.9-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:3ef0cc774b00fec123f635ce5c547dac263f6ee9fb9cc83437c5904183b55ceb"},
-    {file = "ruff-0.6.9-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:12edd2af0c60fa61ff31cefb90aef4288ac4d372b4962c2864aeea3a1a2460c0"},
-    {file = "ruff-0.6.9-py3-none-musllinux_1_2_i686.whl", hash = "sha256:55bb01caeaf3a60b2b2bba07308a02fca6ab56233302406ed5245180a05c5625"},
-    {file = "ruff-0.6.9-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:925d26471fa24b0ce5a6cdfab1bb526fb4159952385f386bdcc643813d472039"},
-    {file = "ruff-0.6.9-py3-none-win32.whl", hash = "sha256:eb61ec9bdb2506cffd492e05ac40e5bc6284873aceb605503d8494180d6fc84d"},
-    {file = "ruff-0.6.9-py3-none-win_amd64.whl", hash = "sha256:785d31851c1ae91f45b3d8fe23b8ae4b5170089021fbb42402d811135f0b7117"},
-    {file = "ruff-0.6.9-py3-none-win_arm64.whl", hash = "sha256:a9641e31476d601f83cd602608739a0840e348bda93fec9f1ee816f8b6798b93"},
-    {file = "ruff-0.6.9.tar.gz", hash = "sha256:b076ef717a8e5bc819514ee1d602bbdca5b4420ae13a9cf61a0c0a4f53a2baa2"},
+    {file = "ruff-0.11.5-py3-none-linux_armv6l.whl", hash = "sha256:2561294e108eb648e50f210671cc56aee590fb6167b594144401532138c66c7b"},
+    {file = "ruff-0.11.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ac12884b9e005c12d0bd121f56ccf8033e1614f736f766c118ad60780882a077"},
+    {file = "ruff-0.11.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:4bfd80a6ec559a5eeb96c33f832418bf0fb96752de0539905cf7b0cc1d31d779"},
+    {file = "ruff-0.11.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0947c0a1afa75dcb5db4b34b070ec2bccee869d40e6cc8ab25aca11a7d527794"},
+    {file = "ruff-0.11.5-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ad871ff74b5ec9caa66cb725b85d4ef89b53f8170f47c3406e32ef040400b038"},
+    {file = "ruff-0.11.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e6cf918390cfe46d240732d4d72fa6e18e528ca1f60e318a10835cf2fa3dc19f"},
+    {file = "ruff-0.11.5-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:56145ee1478582f61c08f21076dc59153310d606ad663acc00ea3ab5b2125f82"},
+    {file = "ruff-0.11.5-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e5f66f8f1e8c9fc594cbd66fbc5f246a8d91f916cb9667e80208663ec3728304"},
+    {file = "ruff-0.11.5-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:80b4df4d335a80315ab9afc81ed1cff62be112bd165e162b5eed8ac55bfc8470"},
+    {file = "ruff-0.11.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3068befab73620b8a0cc2431bd46b3cd619bc17d6f7695a3e1bb166b652c382a"},
+    {file = "ruff-0.11.5-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:f5da2e710a9641828e09aa98b92c9ebbc60518fdf3921241326ca3e8f8e55b8b"},
+    {file = "ruff-0.11.5-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:ef39f19cb8ec98cbc762344921e216f3857a06c47412030374fffd413fb8fd3a"},
+    {file = "ruff-0.11.5-py3-none-musllinux_1_2_i686.whl", hash = "sha256:b2a7cedf47244f431fd11aa5a7e2806dda2e0c365873bda7834e8f7d785ae159"},
+    {file = "ruff-0.11.5-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:81be52e7519f3d1a0beadcf8e974715b2dfc808ae8ec729ecfc79bddf8dbb783"},
+    {file = "ruff-0.11.5-py3-none-win32.whl", hash = "sha256:e268da7b40f56e3eca571508a7e567e794f9bfcc0f412c4b607931d3af9c4afe"},
+    {file = "ruff-0.11.5-py3-none-win_amd64.whl", hash = "sha256:6c6dc38af3cfe2863213ea25b6dc616d679205732dc0fb673356c2d69608f800"},
+    {file = "ruff-0.11.5-py3-none-win_arm64.whl", hash = "sha256:67e241b4314f4eacf14a601d586026a962f4002a475aa702c69980a38087aa4e"},
+    {file = "ruff-0.11.5.tar.gz", hash = "sha256:cae2e2439cb88853e421901ec040a758960b576126dab520fa08e9de431d1bef"},
 ]
 
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.13"
-content-hash = "a721ad007d4edbe0315e9d4d9ef3751a4df816f6c4ccc06d2e9d884243ba1f46"
+content-hash = "132d86aaf15f15aad57203ebdfeb363df13c5b27eefce40d8698baf2b3746fbc"

--- a/packages/ruff-config/pyproject.toml
+++ b/packages/ruff-config/pyproject.toml
@@ -11,7 +11,7 @@ keywords = [
   "spear"
 ]
 readme = "README.md"
-dependencies = ["ruff (>=0.6.4,<0.7.0)"]
+dependencies = ["ruff==0.11.5"]
 
 [project.urls]
 Repository = "https://github.com/spear-ai/citizen"

--- a/packages/ruff-config/pyproject.toml
+++ b/packages/ruff-config/pyproject.toml
@@ -1,24 +1,24 @@
+[build-system]
+build-backend = "poetry.core.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+
 [project]
-requires-python = ">=3.10,<3.13"
-name = "spear-ai-ruff-config"
-version = "5.0.1"
-description = "Spear AI Ruff config"
 authors = [{ name = "Spear AI", email = "org@spear.ai" }]
+dependencies = ["ruff==0.11.5"]
+description = "Spear AI Ruff config"
 keywords = [
   "ai",
   "config",
   "ruff",
   "spear"
 ]
+name = "spear-ai-ruff-config"
 readme = "README.md"
-dependencies = ["ruff==0.11.5"]
+requires-python = ">=3.10,<3.13"
+version = "5.0.1"
 
 [project.urls]
 Repository = "https://github.com/spear-ai/citizen"
 
 [tool.poetry]
 packages = [{ include = "spear_ai_ruff_config" }]
-
-[build-system]
-build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core>=1.0.0"]

--- a/packages/ruff-config/spear_ai_ruff_config/config.toml
+++ b/packages/ruff-config/spear_ai_ruff_config/config.toml
@@ -1,5 +1,4 @@
 line-length = 120
-target-version = "py311"
 
 [lint]
 allowed-confusables = [


### PR DESCRIPTION
## Description
Newer versions of Ruff are able to infer the python version target from the pyproject.toml file, which would remove independent redundant python version specifications from our configuration.

I upgraded Ruff to version 11 to enable Python version inference.
I removed the Ruff Python 3.11 version pin.
I updated the README.
I updated the Poetry lock file.

Major version bump, as this could be a breaking change for some projects.

## Testing

The output of the following command shows that Ruff is correctly using Python 3.10:
`poetry run ruff check --show-settings`
...
`linter.unresolved_target_version = 3.10`
...
`formatter.unresolved_target_version = 3.10`
...
`analyze.target_version = 3.10`

If Ruff is unable to read the version requirement from pyproject.toml, it defaults to 3.8.  So, this command shows that it is correctly inferring the python version after this change.

## Issues

- Closes #559 
