### PR TITLE
Readme trivial change

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ let series; // 1, 2, 3, …, 10
 let series; // 1, 2, 3, ..., 10
 ```
 
-### ¶ cE.jF: DO use en dashes instead of hypens
+### ¶ cE.jF: DO use en dashes instead of hyphens
 
 Do use an en dash when appropriate such as for spans and ranges.
 
@@ -132,7 +132,7 @@ let duration; // 2–3 weeks
 let duration; // 2-3 weeks, 2 to 3 weeks
 ```
 
-### ¶ cE.Cc: DO use em dashes instead of hypens
+### ¶ cE.Cc: DO use em dashes instead of hyphens
 
 Do use an em dash when appropriate such as replacing commas, parentheses, or colons⁠.
 


### PR DESCRIPTION
Fix typos in README by changing "hypens" to "hyphens".

---
[Slack Thread](https://spearai.slack.com/archives/C02DJKY7JFM/p1769343029004409?thread_ts=1769343029.004409&cid=C02DJKY7JFM)

<a href="https://cursor.com/background-agent?bcId=bc-57aa7876-28f8-447c-85f4-d3ce05070f72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-57aa7876-28f8-447c-85f4-d3ce05070f72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

